### PR TITLE
avoid using the `pure` macro for `fieldnames`

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -7,7 +7,7 @@ abstract type AbstractUnits{D<:AbstractDimensions} <: AbstractUnitLike end
 abstract type AbstractAffineUnits{D<:AbstractDimensions} <: AbstractUnits{D} end 
 
 const AbstractAffineLike{D} = Union{D, AbstractAffineUnits{D}} where D <: AbstractDimensions
-Base.@pure static_fieldnames(t::Type) = Base.fieldnames(t)
+Base.@assume_effects :consistent static_fieldnames(t::Type) = Base.fieldnames(t)
 Base.eltype(::Type{<:AbstractDimensions{P}}) where P = P
 
 #=======================================================================================


### PR DESCRIPTION
This internal macro is being removed from Julia. Using it is a bug. It is also a no-op on recent Julia versions as far as I remember.

Replace the usage of the `pure` macro with usage of the `assume_effects` macro.

NB: I do not endorse this usage of `assume_effects`, this is meant as merely the immediate, short-term, fix. There should be a way to redesign the package so this kind of effect assertion (on a generic method that is not even owned by this package) would not be necessary. That said, although this kind of effect assertion is a bit ugly, I don't think there would be any problem in practice even if you kept it forever, as `fieldnames(::Type)` really should be `consistent`.