### PR TITLE
prevent adding new methods to functions `>`, `>=`

### DIFF
--- a/src/math.jl
+++ b/src/math.jl
@@ -144,7 +144,7 @@ Base.one(::Type{<:AbstractQuantity{T}}) where T = one(T) #unitless
 Base.oneunit(::Type{<:AbstractQuantity{T,D}}) where {T,D} = quantity(one(T), zero(D)) #unitless with type
 
 #Comparison functions
-for f in (:<, :>, :<=, :>=)
+for f in (:<, :<=)
     @eval function Base.$f(q1::AbstractQuantity, q2::AbstractQuantity)
         (b1, b2) = (ubase(q1), ubase(q2))
         unit(b1) == unit(b2) || throw(DimensionError(unit(b1), unit(b2)))


### PR DESCRIPTION
It is not necessary or intended to add these methods. Adding these methods happens to invalidate a bunch of the sysimage.

Cross-references:

* PR JuliaDiff/ForwardDiff.jl#771

* PR jump-dev/JuMP.jl#4065

* PR JuliaArrays/AxisArrays.jl#235

* PR JuliaPhysics/DynamicQuantities.jl#189