### PR TITLE
Add some markdown

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -120,7 +120,7 @@ end
 """
     dimension_names(::Type{<:AbstractDimensions})
 
-Overloadable feieldnames for a dimension (returns a tuple of the dimensions field names)
+Overloadable fieldnames for a dimension (returns a tuple of the dimension's field names)
 This should be static so that it can be hardcoded during compilation. 
 Can use this to overload the default "fieldnames" behaviour
 """


### PR DESCRIPTION
Then the docstrings look better. Right now there's no syntax highlighting

<img width="998" height="347" alt="{480A9CA3-CF57-4A38-8A4A-9DAF6CBA9A21}" src="https://github.com/user-attachments/assets/7bb90193-1106-48b6-be5b-f568d7b08af6" />

Obviously this is just one file, the other files are TODO.

Even better is to setup https://documenter.juliadocs.org/stable/man/doctests/