### PR TITLE
Improved performance of DimsMod, fixed some docs issues

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,8 +24,8 @@ jobs:
       matrix:
         version:
           - '1.10'
-          - '1.11'
           - '1.12'
+          - '1.13'
           #- 'pre'
         os:
           - ubuntu-latest

--- a/ToDo.txt
+++ b/ToDo.txt
@@ -1,7 +1,8 @@
 Changelog:
-1.  Default simplifier is general, allowing for custom modules to specialize rather than overwrite
-2.  Added `flipsign` methods
-3.  Slight speedup of many operations
+1.  Fixed an issue where ForwardDiff multiplication with 3 or more terms resulted in type-instability 
+2.  Improved performance of `DimsMod` constructor to improve type inferrability
+    -   Can now NamedTuple instead of keywords for construction, which improves type-stability
+    -   `DimsMod{D"1/s"}(FallingObjectState, (v=dv, h=dh))`
 
 Backlog:
 

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -13,13 +13,7 @@ In the section below, we introduce a strategy that can validate units inside dif
 2. It introduces no added complexity, using the ODE solvers as the developers intended (and test for )
 3. It validates units in a way that is easy to interpret
 
-This strategy involves defining new objects that behave like a user-defined object with units inside the differential equation system, but behave like numerical vectors inside the differential equation solver. This can be done with the following steps
-
-1. Define a modified `FieldVector` object (from StaticArrays) called `QuantFieldVector` that stores values with static dimensions
-2. Override `getindex` so that it that produces raw numbers in base SI units when indexed like a vector (but still produces quantities with field access)
-3. Define new objects with clear dimensional representations and subtype it to `QuantFieldVector`
-
-Note that in the near future, FlexUnits may define its own `QuantFieldVector` object, simplifying this process.
+This strategy involves defining new objects that behave like a user-defined object with units inside the differential equation system, but behave like numerical vectors inside the differential equation solver. This can be done by defining new objects with clear dimensional representations and subtype it to `QuantFieldVector` abstract class defined in FlexUnits
 
 #### The problem definition
 Let us consider an application where we are using the drag force equation to model a falling object with velocity `v` and position `h`. This equation also requires us to consider the following parameters:
@@ -56,7 +50,10 @@ end
 end 
 ```
 
-We can write out the equations as we would normally express them; when returning the value, we need to modify the dimensions by `1/s` for the derivative. The `ustrip` command ensures the output type is the same as the input type (a requirement for the ode solver)
+We can write out the equations as we would normally express them; when returning the value, we need to modify the dimensions by `1/s` for the derivative. This is done using the `DimsMod{D"1/s"}` object constructor which modifies a `QuantFieldArray` object by a static dimension type `D"1/s"` to produce a time derivative. The constructor takes two arguments:
+1. The original object (`FallingObjectState`)
+2. A `NamedTuple` with fields identical to the original object, and values which are quantities having the modified dimensions
+
 ```julia
 function acceleration(u0::AbstractVector, p::FallingObjectProps, t)
     u = FallingObjectState(u0)
@@ -64,11 +61,13 @@ function acceleration(u0::AbstractVector, p::FallingObjectProps, t)
     #Drag force
     fd = -sign(u.v)*0.5*p.ρ*u.v^2*p.Cd*p.A
     
-    #Drag force effect on state (multiply by dt to make units work)
+    #Drag force effect on state, DimsMod validates the units of the derivative
     dv = (fd/p.m - p.g)
     dh = u.v
 
-    return ustrip(DimsMod{D"1/s"}(FallingObjectState, v=dv, h=dh))
+    #Validate the units using DimsMod and return the original type (as required by the ODE solver)
+    du = DimsMod{D"1/s"}(FallingObjectState, (v=dv, h=dh))
+    return convert(typeof(u0), du)
 end
 ```
 

--- a/experiments/diffeq_attempt.jl
+++ b/experiments/diffeq_attempt.jl
@@ -11,7 +11,7 @@ using LinearAlgebra
 #OrdinaryDiffEq.OrdinaryDiffEqCore.DiffEqBase.value(q::Quantity) = dstrip(q)
 
 # =============================================================================================================
-include("diffeq_extension.jl")
+#include("diffeq_extension.jl")
 
 @kwdef struct FallingObjectState{T} <: FieldVector{2,T}
     v  :: T

--- a/src/math.jl
+++ b/src/math.jl
@@ -24,7 +24,7 @@ isknown(d::D) where D<:AbstractDimensions = !isunknown(d, dimension_names(D)[end
 isunknown(d::StaticDims{D}) where D = isunknown(D)
 isknown(d::StaticDims{D}) where D = isknown(D)
 
-#Checks equality of dimensions, returns first non-mirrored dimension
+#Checks equality of dimensions, prioritizes returning static, known dimensions
 @inline equaldims(arg1::AbstractDimensions) = arg1
 function equaldims(d1::AbstractDimensions, d2::AbstractDimensions)
     D = promote_type(typeof(d1), typeof(d2))

--- a/src/quantfieldarray.jl
+++ b/src/quantfieldarray.jl
@@ -113,10 +113,30 @@ struct DimsMod{SD<:StaticDims, N, T, D, A<:QuantFieldArray} <: QuantFieldArray{N
     parent :: A 
     DimsMod{SD}(parent::A) where {SD<:StaticDims, N, T, D, A<:QuantFieldArray{N,T,D}} = new{SD, N, T, D, A}(parent)
 end
-DimsMod{D}(::Type{QA}; kwargs...) where {D,QA} = DimsMod{D}(dimsmod(D, QA; kwargs...))
-ustrip(dm::DimsMod) = getfield(dm, :parent)
+DimsMod{D}(::Type{QA}, nt::NamedTuple) where {D,QA} = DimsMod{D}(dimsmod(D, QA, nt))
+DimsMod{D}(::Type{QA}; kwargs...) where {D,QA} = DimsMod{D}(dimsmod(D, QA, NamedTuple(kwargs)))
 
+modstrip(dm::DimsMod) = getfield(dm, :parent)
+Base.convert(::Type{QA}, dm::DimsMod) where QA <: QuantFieldArray = convert(QA, modstrip(dm))
 
+@generated function dimsmod(::Type{D}, ::Type{QA}, nt::NamedTuple) where {D<:StaticDims, QA<:QuantFieldArray}
+    fns = fieldnames(QA)
+    fus = fieldunits(QA).*D()
+    expr = :($QA())
+    expr_qa = expr.args
+
+    for (fn, fu) in zip(fns, fus)
+        push!(expr_qa, :(ustrip($fu, nt.$fn)))
+    end
+
+    return expr
+end
+
+Base.getproperty(dm::DimsMod{D}, fn::Symbol) where D = getproperty(modstrip(dm), fn)*D()
+Base.getindex(dm::DimsMod, ind::Int) = getindex(modstrip(dm), ind)
+
+#=
+#Older version which used keyword arguments. For some reason, this was type-unstable; NamedTuple improved performance
 @generated function dimsmod(::Type{D}, ::Type{QA}; kwargs...) where {D<:StaticDims, QA<:QuantFieldArray}
     fns = fieldnames(QA)
     fus = fieldunits(QA).*D()
@@ -130,7 +150,4 @@ ustrip(dm::DimsMod) = getfield(dm, :parent)
 
     return expr
 end
-
-Base.getproperty(dm::DimsMod{D}, fn::Symbol) where D = getproperty(ustrip(dm), fn)*D()
-Base.getindex(dm::DimsMod, ind::Int) = getindex(ustrip(dm), ind)
-
+=#

--- a/src/types.jl
+++ b/src/types.jl
@@ -189,7 +189,6 @@ this is useful for logarithmic units
     ExpAffTransform(scale::Real, offset::Real)
     ExpAffTransform(; scale, offset)
 """
-
 @kwdef struct ExpAffTransform{T<:Real} <: AbstractUnitTransform
     scale  :: T = 1.0
     offset :: T = 0.0
@@ -610,7 +609,6 @@ Log-Linear Mixture Unit
 
 An object that represents a mixture of logarithmic/linear units, such as dB/m
 """
-
 @kwdef struct LogLinUnits{L<:AbstractUnits{<:Any, <:ExpAffTransform}, U<:Union{AbstractUnits{<:Any, <:AffineTransform}, AbstractDimLike}} <: AbstractUnitLike
     ulog :: L 
     ulin :: U

--- a/test/benchmarks_stiction.jl
+++ b/test/benchmarks_stiction.jl
@@ -27,43 +27,19 @@ end
     vs :: Quantity{T, D"m/s"} #Velocity below which static friction starts to dominate
 end
 
-
-#First method, shown to be slightly faster 
-function lugre_diff(xvec::VT, θ, t) where VT<:AbstractVector
-    x = ValveState(xvec)
-    u = interpolate(θ.u, t, order=1)
-   
-    gv = θ.Fc + θ.Fs*exp(-abs(x.v/θ.vs))
-    ż  = x.v - (θ.σ₀/gv)*(x.z*abs(x.v))
-    Ff = θ.σ₀*x.z + θ.σ₁*ż + θ.μD*x.v
-    Fnet = (θ.k*(u-x.x) - Ff) #Force balance
-
-    return SVector(ValveState(
-        x = ustrip(D"m/s", x.v),
-        v = ustrip(D"m/s^2", Fnet/θ.m), 
-        z = ustrip(D"m/s", ż)
-    ))
-end
-
-
-#Second method, slightly slower
-#=
 function lugre_diff(xvec::AbstractVector, θ, t)
     x = ValveState(xvec)
     u = interpolate(θ.u, t, order=1)
    
     gv = θ.Fc + θ.Fs*exp(-abs(x.v/θ.vs))
-    ż  = x.v - (θ.σ₀/gv)*(x.z*abs(x.v))
+    ż  = x.v - (θ.σ₀/gv)*x.z*abs(x.v)
     Ff = θ.σ₀*x.z + θ.σ₁*ż + θ.μD*x.v
     Fnet = (θ.k*(u-x.x) - Ff) #Force balance
 
-    return SVector(DimsMod{D"1/s"}(ValveState,
-        x = x.v,
-        v = Fnet/θ.m, 
-        z = ż
-    ))
+    #Validate units of the results, then return the unitless version
+    dx = DimsMod{D"1/s"}(ValveState, (x = x.v, v = Fnet/θ.m, z = ż))
+    return SVector(dx)
 end
-=#
 
 Δt = (0.0, 30.0)
 vt = LinRange(Δt[begin], Δt[end], 10)
@@ -86,6 +62,11 @@ reltol = SA[1e-6, 1e-6, 1e-6]
 prob = ODEProblem{false, FullSpecialize}(lugre_diff, x0, Δt, θ, abstol=abstol, reltol=reltol)
 sol = solve(prob, Rodas4P())
 @btime solve(prob, Rodas4P())
+#=
+@profview for ii in 1:100
+    solve(prob, Rodas4P())
+end
+=#
 
 #=
 using Plots


### PR DESCRIPTION
1.  Fixed an issue where ForwardDiff multiplication with 3 or more terms resulted in type-instability 
2.  Improved performance of `DimsMod` constructor to improve type inferrability
    -   Can now NamedTuple instead of keywords for construction, which improves type-stability
    -   `DimsMod{D"1/s"}(FallingObjectState, (v=dv, h=dh))`